### PR TITLE
Package API class

### DIFF
--- a/taskotron_python_versions/common.py
+++ b/taskotron_python_versions/common.py
@@ -1,7 +1,51 @@
 import logging
+import os
+
+import rpm
 
 log = logging.getLogger('python-versions')
 log.setLevel(logging.DEBUG)
 log.addHandler(logging.NullHandler())
 
 BUG_URL = 'https://github.com/fedora-python/task-python-versions/issues'
+
+
+class PackageException(Exception):
+
+    """Base Exception class for Package API."""
+
+
+class Package(object):
+
+    """RPM Package API."""
+
+    def __init__(self, path):
+        """Given the path to the RPM package, initialize
+        the RPM package header containing its metadata.
+        """
+        self.filename = os.path.basename(path)
+        # To be populated in the first check.
+        self.py_versions = None
+
+        ts = rpm.TransactionSet()
+        with open(path, 'rb') as fdno:
+            try:
+                self.hdr = ts.hdrFromFdno(fdno)
+            except rpm.error as err:
+                raise PackageException('{}: {}'.format(self.filename, err))
+
+    @property
+    def name(self):
+        return self.hdr[rpm.RPMTAG_NAME]
+
+    @property
+    def require_names(self):
+        return self.hdr[rpm.RPMTAG_REQUIRENAME]
+
+    @property
+    def require_nevrs(self):
+        return self.hdr[rpm.RPMTAG_REQUIRENEVRS]
+
+    @property
+    def files(self):
+        return self.hdr[rpm.RPMTAG_FILENAMES]

--- a/test/functional/test_two_three.py
+++ b/test/functional/test_two_three.py
@@ -3,6 +3,7 @@ import os
 
 import pytest
 
+from taskotron_python_versions.common import Package
 from taskotron_python_versions.two_three import check_two_three
 
 
@@ -11,7 +12,7 @@ def pkg(filename):
 
 
 def gpkg(pkgglob):
-    return glob.glob(pkg(pkgglob))[0]
+    return Package(glob.glob(pkg(pkgglob))[0])
 
 
 @pytest.mark.parametrize('pkgglob', ('pyserial*', 'python-peak-rules*',


### PR DESCRIPTION
- [x] add a Package API class to create package objects from RPM paths with all meta-data
- [x] create package objects and pass them into check functions instead of file paths
- [x] rework `two_three` check logic to work with `Package` object
- [x] fix tests to work with the proposed changes

This is the first PR on the way to achieving #5