### PR TITLE
Do not report architecture in the naming_scheme check

### DIFF
--- a/taskotron_python_versions/common.py
+++ b/taskotron_python_versions/common.py
@@ -62,6 +62,11 @@ class Package(object):
         return self.hdr[rpm.RPMTAG_NAME].decode()
 
     @property
+    def nvr(self):
+        """Package name and version as a string."""
+        return self.hdr[rpm.RPMTAG_NVR].decode()
+
+    @property
     def require_names(self):
         return self.hdr[rpm.RPMTAG_REQUIRENAME]
 

--- a/taskotron_python_versions/naming_scheme.py
+++ b/taskotron_python_versions/naming_scheme.py
@@ -58,7 +58,7 @@ def task_naming_scheme(packages, koji_build, artifact):
     from libtaskotron import check
 
     outcome = 'PASSED'
-    incorrect_names = []
+    incorrect_names = set()
 
     name_by_version = collections.defaultdict(set)
     for package in packages:
@@ -78,7 +78,7 @@ def task_naming_scheme(packages, koji_build, artifact):
                 '{} violates the new Python package'
                 ' naming guidelines'.format(package.filename))
             outcome = 'FAILED'
-            incorrect_names.append(package.filename)
+            incorrect_names.add(package.nvr)
         else:
             log.info('{} is using a correct naming scheme'.format(
                 package.filename))

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -138,5 +138,5 @@ def test_artifact_contains_naming_scheme_and_looks_as_expected(copr_results):
 
     assert dedent("""
         These RPMs' names violate the new Python package naming guidelines:
-        {}.noarch.rpm
+        {}
     """).strip().format(result.item) in artifact.strip()


### PR DESCRIPTION
Fixes #13.
Report RPM names without architecture in naming_scheme check to avoid duplication.