### PR TITLE
Requires check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM fedora
 
 RUN dnf -y install --setopt=install_weak_deps=false --setopt=tsflags=nodocs \
     --setopt=deltarpm=false python2-rpm libtaskotron-core libtaskotron-fedora \
-    python3-rpm tox python2 python3 && dnf clean all
+    python3-rpm tox python2 python3 python2-dnf python3-dnf && dnf clean all
 
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,8 @@ You can run the checks locally with
 install it (you can
 follow the
 `Quickstart <https://qa.fedoraproject.org/docs/libtaskotron/latest/quickstart.html>`__).
-You'll also need the ``rpm`` Python 2 module (``python2-rpm``).
+You'll also need the ``rpm`` and ``dnf`` Python 2 modules (``python2-rpm``,
+``python2-dnf``).
 Note that Taskotron unfortunately runs on Python 2, but the code in
 this repository is Python 3 compatible as well.
 
@@ -45,7 +46,7 @@ Tests
 There are also automatic tests available. You can run them using
 `tox <https://tox.readthedocs.io/>`__.
 You'll need the above mentioned dependencies and ``python3-rpm``
-installed as well.
+and ``python3-dnf`` installed as well.
 
 .. code:: console
 

--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,9 @@ Currently the following checks are available:
 -  Whether a package does not require Python 2 and Python 3 at the same
    time;
 
--  Whether the package name follows the Python package naming scheme.
+-  Whether the package name follows the Python package naming scheme;
+
+-  Whether the package uses versioned Python prefix in requirements' names.
 
 Running
 -------

--- a/python_versions_check.py
+++ b/python_versions_check.py
@@ -28,14 +28,19 @@ def run(koji_build, workdir='.', artifactsdir='artifacts'):
     # find files to run on
     files = sorted(os.listdir(workdir))
     packages = []
+    srpm_packages = []
     for file_ in files:
         path = os.path.join(workdir, file_)
         if file_.endswith('.rpm'):
             try:
                 package = Package(path)
-                packages.append(package)
             except PackageException as err:
                 log.error('{}: {}'.format(file_, err))
+            else:
+                if file_.endswith('.src.rpm'):
+                    srpm_packages.append(package)
+                else:
+                    packages.append(package)
         else:
             log.debug('Ignoring non-rpm file: {}'.format(path))
 
@@ -48,7 +53,8 @@ def run(koji_build, workdir='.', artifactsdir='artifacts'):
     details = []
     details.append(task_two_three(packages, koji_build, artifact))
     details.append(task_naming_scheme(packages, koji_build, artifact))
-    details.append(task_requires_naming_scheme(packages, koji_build, artifact))
+    details.append(task_requires_naming_scheme(
+        packages + srpm_packages, koji_build, artifact))
 
     # finally, the main detail with overall results
     outcome = 'PASSED'

--- a/python_versions_check.py
+++ b/python_versions_check.py
@@ -16,6 +16,7 @@ sys.path.insert(0, os.path.dirname(__file__))
 from taskotron_python_versions import (
     task_two_three,
     task_naming_scheme,
+    task_requires_naming_scheme,
 )
 from taskotron_python_versions.common import log, Package, PackageException
 
@@ -47,6 +48,7 @@ def run(koji_build, workdir='.', artifactsdir='artifacts'):
     details = []
     details.append(task_two_three(packages, koji_build, artifact))
     details.append(task_naming_scheme(packages, koji_build, artifact))
+    details.append(task_requires_naming_scheme(packages, koji_build, artifact))
 
     # finally, the main detail with overall results
     outcome = 'PASSED'

--- a/runtask.yml
+++ b/runtask.yml
@@ -13,6 +13,7 @@ input:
 environment:
     rpm:
         - rpm-python
+        - python2-dnf
 
 actions:
     - name: download rpms from koji

--- a/runtask.yml
+++ b/runtask.yml
@@ -20,7 +20,7 @@ actions:
         action: download
         koji_build: ${koji_build}
         arch: ['all']
-        src: False
+        src: True
 
     - name: check each rpm for python dependencies
       python:

--- a/taskotron_python_versions/__init__.py
+++ b/taskotron_python_versions/__init__.py
@@ -1,5 +1,10 @@
-from .two_three import task_two_three
 from .naming_scheme import task_naming_scheme
+from .requires import task_requires_naming_scheme
+from .two_three import task_two_three
 
 
-__all__ = ('task_two_three', 'task_naming_scheme')
+__all__ = (
+    'task_two_three',
+    'task_naming_scheme',
+    'task_requires_naming_scheme',
+)

--- a/taskotron_python_versions/naming_scheme.py
+++ b/taskotron_python_versions/naming_scheme.py
@@ -1,4 +1,5 @@
 import collections
+import os
 
 from .common import log, write_to_artifact
 
@@ -27,6 +28,10 @@ def is_unversioned(name):
 
     Return: (bool) True if used, False otherwise
     """
+    if (os.path.isabs(name) or  # is an executable
+            os.path.splitext(name)[1]):  # has as extension
+        return False
+
     return (
         name.startswith('python-') or
         '-python-' in name or

--- a/taskotron_python_versions/requires.py
+++ b/taskotron_python_versions/requires.py
@@ -3,7 +3,7 @@ import collections
 from .common import log, write_to_artifact
 from .naming_scheme import is_unversioned
 
-MESSAGE = """These RPMs use `python-` prefix without Python version in Requires:
+MESSAGE = """These RPMs use `python-` prefix without Python version in *Requires:
 {}
 This is strongly discouraged and should be avoided. Please check
 the required packages, and use names with either `python2-` or

--- a/taskotron_python_versions/requires.py
+++ b/taskotron_python_versions/requires.py
@@ -1,0 +1,62 @@
+import collections
+
+from .common import log, write_to_artifact
+from .naming_scheme import is_unversioned
+
+MESSAGE = """These RPMs use `python-` prefix without Python version in Requires:
+{}
+This is strongly discouraged and should be avoided. Please check
+the required packages, and use names with either `python2-` or
+`python3-` prefix if available.
+"""
+
+# Should be a link to guidelines when
+# https://pagure.io/packaging-committee/issue/686 accepted.
+INFO_URL = ''
+
+
+def task_requires_naming_scheme(packages, koji_build, artifact):
+    """Check if the given packages use names with `python-` prefix
+    without a version in Requires.
+    """
+    # libtaskotron is not available on Python 3, so we do it inside
+    # to make the above functions testable anyway
+    from libtaskotron import check
+
+    outcome = 'PASSED'
+    misnamed_requires = collections.defaultdict(set)
+
+    for package in packages:
+        log.debug('Checking requires of {}'.format(package.filename))
+        for name in package.require_names:
+            name = name.decode()
+            if is_unversioned(name):
+                log.error(
+                    '{} package uses `python-` prefix without version in '
+                    'the requirement name {}'.format(package.filename, name))
+                misnamed_requires[package.nvr].add(name)
+                outcome = 'FAILED'
+
+    message_rpms = ''
+    for pakcage_name, requires in misnamed_requires.items():
+        message_rpms += '{}\n * Requires: {}\n'.format(
+            pakcage_name, ', '.join(sorted(requires)))
+
+    detail = check.CheckDetail(
+        checkname='python-versions.requires_naming_scheme',
+        item=koji_build,
+        report_type=check.ReportType.KOJI_BUILD,
+        outcome=outcome)
+
+    if misnamed_requires:
+        detail.artifact = artifact
+        write_to_artifact(artifact, MESSAGE.format(message_rpms), INFO_URL)
+        problems = 'Problematic RPMs:\n' + ', '.join(misnamed_requires.keys())
+    else:
+        problems = 'No problems found.'
+
+    summary = 'python-versions.requires_naming_scheme {} for {}. {}'.format(
+        outcome, koji_build, problems)
+    log.info(summary)
+
+    return detail

--- a/test/functional/test_naming_scheme.py
+++ b/test/functional/test_naming_scheme.py
@@ -42,6 +42,8 @@ def test_is_unversioned_positive(name):
     'python3-foo',
     'foo-python3',
     'foo-python3-foo',
+    '/usr/libexec/system-python',
+    'libsamba-python-samba4.so',
 ))
 def test_is_unversioned_negative(name):
     assert not is_unversioned(name)

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -141,3 +141,32 @@ def test_artifact_contains_naming_scheme_and_looks_as_expected(copr_results):
         These RPMs' names violate the new Python package naming guidelines:
         {}
     """).strip().format(result.item) in artifact.strip()
+
+
+@pytest.mark.parametrize('nevr', ('eric-6.1.6-2.fc25',
+                                  'python-epub-0.5.2-8.fc26'))
+def test_requires_naming_scheme_nevr_passed(nevr):
+    task_result = run_task(nevr)['python-versions.requires_naming_scheme']
+    assert task_result.outcome == 'PASSED'
+
+
+def test_requires_naming_scheme_nevr_failed(copr_results):
+    task_result = copr_results['python-versions.requires_naming_scheme']
+    assert task_result.outcome == 'FAILED'
+
+
+def test_artifact_contains_requires_naming_scheme_and_looks_as_expected(
+        tracer_results):
+    result = tracer_results['python-versions.requires_naming_scheme']
+    with open(result.artifact) as f:
+        artifact = f.read()
+
+    assert dedent("""
+        These RPMs use `python-` prefix without Python version in Requires:
+        {}
+         * Requires: python-beautifulsoup4, python-psutil, rpm-python
+
+        This is strongly discouraged and should be avoided. Please check
+        the required packages, and use names with either `python2-` or
+        `python3-` prefix if available.
+    """).strip().format(result.item) in artifact.strip()

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -105,7 +105,8 @@ _twine = fixtures_factory('python-twine-1.8.1-3.fc26')
 twine = fixtures_factory('_twine')
 
 
-@pytest.mark.parametrize('results', ('eric', 'six', 'admesh'))
+@pytest.mark.parametrize('results', ('eric', 'six', 'admesh',
+                                     'copr', 'epub', 'twine'))
 def test_two_three_passed(results, request):
     # getting a fixture by name
     # https://github.com/pytest-dev/pytest/issues/349#issuecomment-112203541
@@ -117,15 +118,20 @@ def test_two_three_failed(tracer):
     assert tracer['python-versions.two_three'].outcome == 'FAILED'
 
 
-@pytest.mark.parametrize('results', ('tracer', 'copr'))
+@pytest.mark.parametrize('results', ('tracer', 'copr', 'admesh'))
 def test_one_failed_result_is_total_failed(results, request):
     results = request.getfixturevalue(results)
     assert results['python-versions'].outcome == 'FAILED'
 
 
-def test_artifact_is_the_same(tracer):
-    assert (tracer['python-versions'].artifact ==
-            tracer['python-versions.two_three'].artifact)
+@pytest.mark.parametrize(('results', 'task'),
+                         (('tracer', 'two_three'),
+                          ('copr', 'naming_scheme'),
+                          ('admesh', 'requires_naming_scheme')))
+def test_artifact_is_the_same(results, task, request):
+    results = request.getfixturevalue(results)
+    assert (results['python-versions'].artifact ==
+            results['python-versions.' + task].artifact)
 
 
 def test_artifact_contains_two_three_and_looks_as_expected(tracer):
@@ -141,14 +147,16 @@ def test_artifact_contains_two_three_and_looks_as_expected(tracer):
     ''').strip().format(result.item) in artifact.strip()
 
 
-@pytest.mark.parametrize('results', ('eric', 'epub'))
+@pytest.mark.parametrize('results', ('eric', 'epub', 'twine'))
 def test_naming_scheme_passed(results, request):
     results = request.getfixturevalue(results)
     assert results['python-versions.naming_scheme'].outcome == 'PASSED'
 
 
-def test_naming_scheme_failed(copr):
-    assert copr['python-versions.naming_scheme'].outcome == 'FAILED'
+@pytest.mark.parametrize('results', ('copr', 'six', 'admesh'))
+def test_naming_scheme_failed(results, request):
+    results = request.getfixturevalue(results)
+    assert results['python-versions.naming_scheme'].outcome == 'FAILED'
 
 
 def test_artifact_contains_naming_scheme_and_looks_as_expected(copr):
@@ -162,15 +170,17 @@ def test_artifact_contains_naming_scheme_and_looks_as_expected(copr):
     """).strip().format(result.item) in artifact.strip()
 
 
-@pytest.mark.parametrize('results', ('eric', 'twine'))
+@pytest.mark.parametrize('results', ('eric', 'twine', 'six'))
 def test_requires_naming_scheme_passed(results, request):
     results = request.getfixturevalue(results)
     task_result = results['python-versions.requires_naming_scheme']
     assert task_result.outcome == 'PASSED'
 
 
-def test_requires_naming_scheme_failed(copr):
-    task_result = copr['python-versions.requires_naming_scheme']
+@pytest.mark.parametrize('results', ('admesh', 'copr'))
+def test_requires_naming_scheme_failed(results, request):
+    results = request.getfixturevalue(results)
+    task_result = results['python-versions.requires_naming_scheme']
     assert task_result.outcome == 'FAILED'
 
 

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -144,7 +144,7 @@ def test_artifact_contains_naming_scheme_and_looks_as_expected(copr_results):
 
 
 @pytest.mark.parametrize('nevr', ('eric-6.1.6-2.fc25',
-                                  'python-epub-0.5.2-8.fc26'))
+                                  'python-twine-1.8.1-3.fc26'))
 def test_requires_naming_scheme_nevr_passed(nevr):
     task_result = run_task(nevr)['python-versions.requires_naming_scheme']
     assert task_result.outcome == 'PASSED'
@@ -161,12 +161,16 @@ def test_artifact_contains_requires_naming_scheme_and_looks_as_expected(
     with open(result.artifact) as f:
         artifact = f.read()
 
+    expected_requires = (
+        'python-beautifulsoup4, python-lxml, python-psutil, '
+        'python-pygments, python-sphinx, rpm-python')
+
     assert dedent("""
-        These RPMs use `python-` prefix without Python version in Requires:
+        These RPMs use `python-` prefix without Python version in *Requires:
         {}
-         * Requires: python-beautifulsoup4, python-psutil, rpm-python
+         * Requires: {}
 
         This is strongly discouraged and should be avoided. Please check
         the required packages, and use names with either `python2-` or
         `python3-` prefix if available.
-    """).strip().format(result.item) in artifact.strip()
+    """).strip().format(result.item, expected_requires) in artifact.strip()

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -61,56 +61,75 @@ def run_task(nevr, *, reterr=False):
     return ret
 
 
-@pytest.fixture()
-def tracer_results(_tracer_results):
-    '''This should FAIL the two_three check'''
-    print(_tracer_results[1], file=sys.stderr)
-    return _tracer_results[0]
+def fixtures_factory(nevr):
+    '''Given the NEVR and later name, create a fixture with the results
+
+    Note that this has to be called twice and assigned to correct names!
+
+    See examples bellow.'''
+    if not nevr.startswith('_'):
+        @pytest.fixture(scope="session")
+        def _results():
+            return run_task(nevr, reterr=True)
+
+        return _results
+
+    @pytest.fixture()
+    def results(request):
+        _results = request.getfixturevalue(nevr)
+        print(_results[1], file=sys.stderr)
+        return _results[0]
+
+    return results
 
 
-@pytest.fixture(scope="session")
-def _tracer_results():
-    return run_task('tracer-0.6.9-1.fc23', reterr=True)
+_tracer = fixtures_factory('tracer-0.6.9-1.fc23')
+tracer = fixtures_factory('_tracer')
+
+_copr = fixtures_factory('python-copr-1.77-1.fc26')
+copr = fixtures_factory('_copr')
+
+_eric = fixtures_factory('eric-6.1.6-2.fc25')
+eric = fixtures_factory('_eric')
+
+_six = fixtures_factory('python-six-1.10.0-3.fc25')
+six = fixtures_factory('_six')
+
+_admesh = fixtures_factory('python-admesh-0.98.5-3.fc25')
+admesh = fixtures_factory('_admesh')
+
+_epub = fixtures_factory('python-epub-0.5.2-8.fc26')
+epub = fixtures_factory('_epub')
+
+_twine = fixtures_factory('python-twine-1.8.1-3.fc26')
+twine = fixtures_factory('_twine')
 
 
-@pytest.fixture()
-def copr_results(_copr_results):
-    '''This should FAIL the name_scheme check'''
-    print(_copr_results[1], file=sys.stderr)
-    return _copr_results[0]
-
-
-@pytest.fixture(scope="session")
-def _copr_results():
-    return run_task('python-copr-1.77-1.fc26', reterr=True)
-
-
-@pytest.mark.parametrize('nevr', ('eric-6.1.6-2.fc25',
-                                  'python-six-1.10.0-3.fc25',
-                                  'python-admesh-0.98.5-3.fc25'))
-def test_two_three_nevr_passed(nevr):
-    assert run_task(nevr)['python-versions.two_three'].outcome == 'PASSED'
-
-
-def test_two_three_nevr_failed(tracer_results):
-    assert tracer_results['python-versions.two_three'].outcome == 'FAILED'
-
-
-@pytest.mark.parametrize('results', ('tracer_results', 'copr_results'))
-def test_one_failed_result_is_total_failed(results, request):
+@pytest.mark.parametrize('results', ('eric', 'six', 'admesh'))
+def test_two_three_passed(results, request):
     # getting a fixture by name
     # https://github.com/pytest-dev/pytest/issues/349#issuecomment-112203541
+    results = request.getfixturevalue(results)
+    assert results['python-versions.two_three'].outcome == 'PASSED'
+
+
+def test_two_three_failed(tracer):
+    assert tracer['python-versions.two_three'].outcome == 'FAILED'
+
+
+@pytest.mark.parametrize('results', ('tracer', 'copr'))
+def test_one_failed_result_is_total_failed(results, request):
     results = request.getfixturevalue(results)
     assert results['python-versions'].outcome == 'FAILED'
 
 
-def test_artifact_is_the_same(tracer_results):
-    assert (tracer_results['python-versions'].artifact ==
-            tracer_results['python-versions.two_three'].artifact)
+def test_artifact_is_the_same(tracer):
+    assert (tracer['python-versions'].artifact ==
+            tracer['python-versions.two_three'].artifact)
 
 
-def test_artifact_contains_two_three_and_looks_as_expected(tracer_results):
-    result = tracer_results['python-versions.two_three']
+def test_artifact_contains_two_three_and_looks_as_expected(tracer):
+    result = tracer['python-versions.two_three']
     with open(result.artifact) as f:
         artifact = f.read()
 
@@ -122,18 +141,18 @@ def test_artifact_contains_two_three_and_looks_as_expected(tracer_results):
     ''').strip().format(result.item) in artifact.strip()
 
 
-@pytest.mark.parametrize('nevr', ('eric-6.1.6-2.fc25',
-                                  'python-epub-0.5.2-8.fc26'))
-def test_naming_scheme_nevr_passed(nevr):
-    assert run_task(nevr)['python-versions.naming_scheme'].outcome == 'PASSED'
+@pytest.mark.parametrize('results', ('eric', 'epub'))
+def test_naming_scheme_passed(results, request):
+    results = request.getfixturevalue(results)
+    assert results['python-versions.naming_scheme'].outcome == 'PASSED'
 
 
-def test_naming_scheme_nevr_failed(copr_results):
-    assert copr_results['python-versions.naming_scheme'].outcome == 'FAILED'
+def test_naming_scheme_failed(copr):
+    assert copr['python-versions.naming_scheme'].outcome == 'FAILED'
 
 
-def test_artifact_contains_naming_scheme_and_looks_as_expected(copr_results):
-    result = copr_results['python-versions.naming_scheme']
+def test_artifact_contains_naming_scheme_and_looks_as_expected(copr):
+    result = copr['python-versions.naming_scheme']
     with open(result.artifact) as f:
         artifact = f.read()
 
@@ -143,21 +162,21 @@ def test_artifact_contains_naming_scheme_and_looks_as_expected(copr_results):
     """).strip().format(result.item) in artifact.strip()
 
 
-@pytest.mark.parametrize('nevr', ('eric-6.1.6-2.fc25',
-                                  'python-twine-1.8.1-3.fc26'))
-def test_requires_naming_scheme_nevr_passed(nevr):
-    task_result = run_task(nevr)['python-versions.requires_naming_scheme']
+@pytest.mark.parametrize('results', ('eric', 'twine'))
+def test_requires_naming_scheme_passed(results, request):
+    results = request.getfixturevalue(results)
+    task_result = results['python-versions.requires_naming_scheme']
     assert task_result.outcome == 'PASSED'
 
 
-def test_requires_naming_scheme_nevr_failed(copr_results):
-    task_result = copr_results['python-versions.requires_naming_scheme']
+def test_requires_naming_scheme_failed(copr):
+    task_result = copr['python-versions.requires_naming_scheme']
     assert task_result.outcome == 'FAILED'
 
 
 def test_artifact_contains_requires_naming_scheme_and_looks_as_expected(
-        tracer_results):
-    result = tracer_results['python-versions.requires_naming_scheme']
+        tracer):
+    result = tracer['python-versions.requires_naming_scheme']
     with open(result.artifact) as f:
         artifact = f.read()
 

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -161,9 +161,9 @@ def test_artifact_contains_requires_naming_scheme_and_looks_as_expected(
     with open(result.artifact) as f:
         artifact = f.read()
 
-    expected_requires = (
-        'python-beautifulsoup4, python-lxml, python-psutil, '
-        'python-pygments, python-sphinx, rpm-python')
+    print(artifact)
+
+    expected_requires = 'python-psutil (python2-psutil is available)'
 
     assert dedent("""
         These RPMs use `python-` prefix without Python version in *Requires:
@@ -172,5 +172,5 @@ def test_artifact_contains_requires_naming_scheme_and_looks_as_expected(
 
         This is strongly discouraged and should be avoided. Please check
         the required packages, and use names with either `python2-` or
-        `python3-` prefix if available.
+        `python3-` prefix.
     """).strip().format(result.item, expected_requires) in artifact.strip()


### PR DESCRIPTION
- [x] check if the package uses versioned Python prefix in requirements' names
- [x] add integration tests for this check
- [x] modify the shared `is_unversioned` function to disregard requirements like `/usr/libexec/system-python` or
`libsamba-python-samba4.so` (it should be ok to fix this directly in the shared function as it should be propagated to portingdb as well)
- [x] Check also Build requires
- [x] Unit tests

~~Note: this task will fail even if the correct name is not provided by the required package. And I am not sure if we can check if it is provided. Maybe we could change the outcome to smth like NEEDS_INSPECTION, or look for a way to check this. Any thoughts?~~

As part of #5.