### PR TITLE
Improve artifact report for requires check

### DIFF
--- a/python_versions_check.py
+++ b/python_versions_check.py
@@ -37,7 +37,7 @@ def run(koji_build, workdir='.', artifactsdir='artifacts'):
             except PackageException as err:
                 log.error('{}: {}'.format(file_, err))
             else:
-                if file_.endswith('.src.rpm'):
+                if package.is_srpm:
                     srpm_packages.append(package)
                 else:
                     packages.append(package)
@@ -54,7 +54,7 @@ def run(koji_build, workdir='.', artifactsdir='artifacts'):
     details.append(task_two_three(packages, koji_build, artifact))
     details.append(task_naming_scheme(packages, koji_build, artifact))
     details.append(task_requires_naming_scheme(
-        packages + srpm_packages, koji_build, artifact))
+        srpm_packages + packages, koji_build, artifact))
 
     # finally, the main detail with overall results
     outcome = 'PASSED'

--- a/taskotron_python_versions/common.py
+++ b/taskotron_python_versions/common.py
@@ -57,6 +57,10 @@ class Package(object):
                 raise PackageException('{}: {}'.format(self.filename, err))
 
     @property
+    def is_srpm(self):
+        return self.filename.endswith('.src.rpm')
+
+    @property
     def name(self):
         """Package name as a string."""
         return self.hdr[rpm.RPMTAG_NAME].decode()

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -201,14 +201,16 @@ def test_artifact_contains_requires_naming_scheme_and_looks_as_expected(
 
     print(artifact)
 
-    expected_requires = 'python-psutil (python2-psutil is available)'
-
     assert dedent("""
         These RPMs use `python-` prefix without Python version in *Requires:
-        {}
-         * Requires: {}
+
+        tracer-0.6.9-1.fc23 BuildRequires:
+         * python-psutil (python2-psutil is available)
+
+        tracer-0.6.9-1.fc23 Requires:
+         * python-psutil (python2-psutil is available)
 
         This is strongly discouraged and should be avoided. Please check
         the required packages, and use names with either `python2-` or
         `python3-` prefix.
-    """).strip().format(result.item, expected_requires) in artifact.strip()
+    """).strip() in artifact.strip()


### PR DESCRIPTION
* Better formatting for requires of each package
* Source rpm result (BuildRequires) on top

Also fixes an important bug, when rpm and srpm have the same NVR.
Previously it generated one result for both packages in such cases.
Now BuildRequires are displayed separately.
This was caught by the integration test.

Fixes #20