### PR TITLE
Change info link for requires check

### DIFF
--- a/taskotron_python_versions/requires.py
+++ b/taskotron_python_versions/requires.py
@@ -10,8 +10,8 @@ the required packages, and use names with either `python2-` or
 `python3-` prefix.
 """
 
-# TODO: Should be a link to guidelines when considered.
-INFO_URL = 'https://pagure.io/packaging-committee/issue/686'
+
+INFO_URL = 'https://fedoraproject.org/wiki/Packaging:Python#Dependencies'
 
 
 class DNFQuery(object):


### PR DESCRIPTION
The FPC ticket has already been discussed and the guidelines were
altered. Thus we now can use the Fedora packaging guidelines as a link
for requires check, rather than the link to the ticket.