### PR TITLE
Don't check Python 3 packages for naming policy

### DIFF
--- a/taskotron_python_versions/naming_scheme.py
+++ b/taskotron_python_versions/naming_scheme.py
@@ -73,9 +73,9 @@ def task_naming_scheme(packages, koji_build, artifact):
 
     for package in packages:
         log.debug('Checking {}'.format(package.filename))
-        if not package.py_versions:
-            log.info('{} does not require Python, skipping name check'.format(
-                package.filename))
+        if 2 not in package.py_versions:
+            log.info('{} does not require Python 2, '
+                     'skipping name check'.format(package.filename))
             continue
 
         misnamed = check_naming_policy(package, name_by_version)

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -107,9 +107,13 @@ twine = fixtures_factory('_twine')
 _yum = fixtures_factory('yum-3.4.3-512.fc26')
 yum = fixtures_factory('_yum')
 
+_vdirsyncer = fixtures_factory('vdirsyncer-0.16.0-1.fc27')
+vdirsyncer = fixtures_factory('_vdirsyncer')
+
 
 @pytest.mark.parametrize('results', ('eric', 'six', 'admesh', 'tracer',
-                                     'copr', 'epub', 'twine', 'yum'))
+                                     'copr', 'epub', 'twine', 'yum',
+                                     'vdirsyncer'))
 def test_number_of_results(results, request):
     # getting a fixture by name
     # https://github.com/pytest-dev/pytest/issues/349#issuecomment-112203541
@@ -159,7 +163,7 @@ def test_artifact_contains_two_three_and_looks_as_expected(tracer):
     ''').strip().format(result.item) in artifact.strip()
 
 
-@pytest.mark.parametrize('results', ('eric', 'epub', 'twine'))
+@pytest.mark.parametrize('results', ('eric', 'epub', 'twine', 'vdirsyncer'))
 def test_naming_scheme_passed(results, request):
     results = request.getfixturevalue(results)
     assert results['python-versions.naming_scheme'].outcome == 'PASSED'


### PR DESCRIPTION
Workarounds https://github.com/fedora-python/taskotron-python-versions/issues/25

Adding vdirsyncer to test_integration as a regression test.

Obsoletes https://github.com/fedora-python/taskotron-python-versions/pull/26