### PR TITLE
Include python-btchip-common in NAME_NOTS

### DIFF
--- a/taskotron_python_versions/two_three.py
+++ b/taskotron_python_versions/two_three.py
@@ -39,6 +39,7 @@ NAME_NOTS = (
     b'python-multilib-conf',
     b'python-ldb-devel-common',
     b'python-qt5-rpm-macros',
+    b'python-btchip-common',
 )
 
 


### PR DESCRIPTION
`python-btchip-common` is common between `python2-btchip` and `python3-btchip`, because at present it shares a single udev rule necessary for the hardware to work. It contains NO python, and is being recognized as "python2" because of the prefix.