### PR TITLE
Make sure Bugzilla is queried without being logged in

### DIFF
--- a/taskotron_python_versions/py3_support.py
+++ b/taskotron_python_versions/py3_support.py
@@ -61,7 +61,7 @@ def get_py3_bugzillas_for(srpm_name):
 
     Return: (list) List of Bugzilla URLs
     """
-    bzapi = bugzilla.Bugzilla(BUGZILLA_URL)
+    bzapi = bugzilla.Bugzilla(BUGZILLA_URL, cookiefile=None, tokenfile=None)
     query = bzapi.build_query(
         product="Fedora",
         component=srpm_name)


### PR DESCRIPTION
After a few months of not running the integration tests
I ended up with a strange error message:

<Fault 32000: 'The cookies or token provide were not valid or have
expired. You may login again to get new cookies or a new token.'>

Apparently, bugzilla.Bugzilla(...) is logging me in with some
credentials from god-knows-where. It worked last time, but in the
meantime, those credentials have expired.

I found a discussion about this at [1], and went with a solution
that disables this automatic logging in, keeping the Bugzilla
query anonymous. That fixed my issue.

[1]: https://lists.fedorahosted.org/archives/list/python-bugzilla@lists.fedorahosted.org/message/A2ZUGBFWATW676YRPJMTL2F2WYWT5RMB/