### PR TITLE
Add a test for /usr/bin/python invocation warning

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,6 +19,8 @@ Currently the following checks are available:
 
 -  Whether the package supports Python 3 upstream but not in the package.
 
+-  Whether ``/usr/bin/python`` was invoked during the build.
+
 
 Running
 -------

--- a/runtask.yml
+++ b/runtask.yml
@@ -24,6 +24,7 @@ actions:
         koji_build: ${koji_build}
         arch: ['all']
         src: True
+        build_log: True
 
     - name: check each rpm for python dependencies
       python:

--- a/taskotron_python_versions/__init__.py
+++ b/taskotron_python_versions/__init__.py
@@ -4,6 +4,7 @@ from .requires import task_requires_naming_scheme
 from .two_three import task_two_three
 from .unversioned_shebangs import task_unversioned_shebangs
 from .py3_support import task_py3_support
+from .python_usage import task_python_usage
 
 
 __all__ = (
@@ -13,4 +14,5 @@ __all__ = (
     'task_executables',
     'task_unversioned_shebangs',
     'task_py3_support',
+    'task_python_usage',
 )

--- a/taskotron_python_versions/python_usage.py
+++ b/taskotron_python_versions/python_usage.py
@@ -1,0 +1,81 @@
+import mmap
+
+from .common import log, write_to_artifact
+
+
+MESSAGE = """You've used /usr/bin/python during build on the following arches:
+
+  {}
+
+Use /usr/bin/python3 or /usr/bin/python2 explicitly.
+/usr/bin/python will be removed or switched to Python 3 in the future.
+"""
+
+INFO_URL = ('https://fedoraproject.org/wiki/Changes/'
+            'Avoid_usr_bin_python_in_RPM_Build')
+WARNING = 'DEPRECATION WARNING: python2 invoked with /usr/bin/python'
+
+
+def file_contains(path, needle):
+    """Check if the file residing on the given path contains the given needle
+    """
+    # Since we have no idea if build.log is valid utf8, let's convert our ASCII
+    # needle to bytes and use bytes everywhere.
+    # This also allow us to use mmap on Python 3.
+    # Be explicit here, to make it fail early if our needle is not ASCII.
+    needle = needle.encode('ascii')
+
+    with open(path, 'rb') as f:
+        # build.logs tend to be laaaarge, so using a single read() is bad idea;
+        # let's optimize prematurely because practicality beats purity
+
+        # Memory-mapped file object behaving like bytearray
+        mmf = mmap.mmap(f.fileno(),
+                        length=0,  # = determine automatically
+                        access=mmap.ACCESS_READ)
+        try:
+            return mmf.find(needle) != -1
+        finally:
+            # mmap context manager is Python 3 only
+            mmf.close()
+
+
+def task_python_usage(logs, koji_build, artifact):
+    """Parses the build.logs for /usr/bin/python invocation warning
+    """
+    # libtaskotron is not available on Python 3, so we do it inside
+    # to make the above functions testable anyway
+    from libtaskotron import check
+
+    outcome = 'PASSED'
+
+    problem_arches = set()
+
+    for buildlog in logs:  # not "log" because we use that name for logging
+        log.debug('Will parse {}'.format(buildlog))
+
+        if file_contains(buildlog, WARNING):
+            log.debug('{} contains our warning'.format(buildlog))
+            _, _, arch = buildlog.rpartition('.')
+            problem_arches.add(arch)
+            outcome = 'FAILED'
+
+    detail = check.CheckDetail(
+        checkname='python-versions.python_usage',
+        item=koji_build,
+        report_type=check.ReportType.KOJI_BUILD,
+        outcome=outcome)
+
+    if problem_arches:
+        detail.artifact = artifact
+        archstr = ', '.join(problem_arches)
+        write_to_artifact(artifact, MESSAGE.format(archstr), INFO_URL)
+        problems = 'Problematic architectures: ' + archstr
+    else:
+        problems = 'No problems found.'
+
+    summary = 'python-versions.python_usage {} for {}. {}'.format(
+        outcome, koji_build, problems)
+    log.info(summary)
+
+    return detail

--- a/test/functional/test_python_usage.py
+++ b/test/functional/test_python_usage.py
@@ -1,0 +1,32 @@
+import pytest
+
+from taskotron_python_versions.python_usage import file_contains
+
+from .common import gpkg_path
+
+
+@pytest.mark.parametrize('thing', ('Whither Canada?',
+                                   'Sex and Violence',
+                                   'Owl Stretching Time',
+                                   'Full Frontal Nudity'))
+def test_this_file_contains_things_it_does(thing):
+    # given the nature of this test, just specifying the parameters makes
+    # the file contain them (mindblown!)
+    assert file_contains(__file__, thing)
+
+
+@pytest.mark.parametrize('thing', ('How to Recognise Different Types of Trees'
+                                   ' From Quite a Long Way Away',
+                                   'Man\'s Crisis of Identity in the Latter'
+                                   ' Half of the 20th Century',
+                                   'You\'re No Fun Anymore'))
+def test_this_file_doesnt_contain_things_it_doesnt(thing):
+    # given the nature of this test, all the things have to be a bit obfuscated
+    assert not file_contains(__file__, thing)
+
+
+@pytest.mark.parametrize(('word', 'is_in'), (('python', True),
+                                             ('abracadabra', False)))
+def test_searching_in_weird_logs(word, is_in):
+    fake_log = gpkg_path('yum*')
+    assert file_contains(fake_log, word) == is_in

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -130,7 +130,7 @@ def test_number_of_results(results, request):
     results = request.getfixturevalue(results)
 
     # Each time a new check is added, this number needs to be increased
-    assert len(results) == 7
+    assert len(results) == 8
 
 
 @pytest.mark.parametrize('results', ('eric', 'six', 'admesh',
@@ -358,3 +358,15 @@ def test_artifact_contains_py3_support_and_looks_as_expected(
         See the following Bugzilla:
         https://bugzilla.redhat.com/show_bug.cgi?id=1367012
     """).strip() in artifact.strip()
+
+
+@pytest.mark.parametrize('results', ('eric', 'six', 'admesh', 'tracer',
+                                     'copr', 'epub', 'twine', 'docutils'))
+def test_python_usage_passed(results, request):
+    results = request.getfixturevalue(results)
+    task_result = results['python-versions.python_usage']
+    assert task_result.outcome == 'PASSED'
+
+
+# TODO add a FAILED integration test for python_usage (not possible yet)
+# TODO add an artifact integration test for the above


### PR DESCRIPTION
See https://github.com/fedora-python/taskotron-python-versions/issues/38

This has several TODOs waiting for external factors. But the code can be reviewed nevertheless.