### PR TITLE
Fix a bug in identifying ambiguous requires

### DIFF
--- a/taskotron_python_versions/naming_scheme.py
+++ b/taskotron_python_versions/naming_scheme.py
@@ -29,7 +29,8 @@ def is_unversioned(name):
     Return: (bool) True if used, False otherwise
     """
     if (os.path.isabs(name) or  # is an executable
-            os.path.splitext(name)[1]):  # has as extension
+            os.path.splitext(name)[1] or  # has as extension
+            name.startswith(('python2-', 'python3-'))):  # is versioned
         return False
 
     return (

--- a/test/functional/test_naming_scheme.py
+++ b/test/functional/test_naming_scheme.py
@@ -42,6 +42,10 @@ def test_is_unversioned_positive(name):
     'python3-foo',
     'foo-python3',
     'foo-python3-foo',
+    'python3-foo-python',
+    'python2-foo-python',
+    'python3-foo-python-foo',
+    'python2-foo-python-foo',
     '/usr/libexec/system-python',
     'libsamba-python-samba4.so',
 ))


### PR DESCRIPTION
There are packages named e.g. `python3-into-dbus-python` or `python2-python-etcd`, which are
incorrectly identified as having unversioned python suffix.