### PR TITLE
Shebang check update

### DIFF
--- a/python_versions_check.py
+++ b/python_versions_check.py
@@ -69,7 +69,8 @@ def run(koji_build, workdir='.', artifactsdir='artifacts',
     details.append(task_requires_naming_scheme(
         srpm_packages + packages, koji_build, artifact))
     details.append(task_executables(packages, koji_build, artifact))
-    details.append(task_unversioned_shebangs(packages, koji_build, artifact))
+    details.append(task_unversioned_shebangs(
+        packages, logs, koji_build, artifact))
     details.append(task_py3_support(
         srpm_packages + packages, koji_build, artifact))
     details.append(task_python_usage(logs, koji_build, artifact))

--- a/taskotron_python_versions/python_usage.py
+++ b/taskotron_python_versions/python_usage.py
@@ -1,6 +1,4 @@
-import mmap
-
-from .common import log, write_to_artifact
+from .common import log, write_to_artifact, file_contains
 
 
 MESSAGE = """You've used /usr/bin/python during build on the following arches:
@@ -14,30 +12,6 @@ Use /usr/bin/python3 or /usr/bin/python2 explicitly.
 INFO_URL = ('https://fedoraproject.org/wiki/Changes/'
             'Avoid_usr_bin_python_in_RPM_Build')
 WARNING = 'DEPRECATION WARNING: python2 invoked with /usr/bin/python'
-
-
-def file_contains(path, needle):
-    """Check if the file residing on the given path contains the given needle
-    """
-    # Since we have no idea if build.log is valid utf8, let's convert our ASCII
-    # needle to bytes and use bytes everywhere.
-    # This also allow us to use mmap on Python 3.
-    # Be explicit here, to make it fail early if our needle is not ASCII.
-    needle = needle.encode('ascii')
-
-    with open(path, 'rb') as f:
-        # build.logs tend to be laaaarge, so using a single read() is bad idea;
-        # let's optimize prematurely because practicality beats purity
-
-        # Memory-mapped file object behaving like bytearray
-        mmf = mmap.mmap(f.fileno(),
-                        length=0,  # = determine automatically
-                        access=mmap.ACCESS_READ)
-        try:
-            return mmf.find(needle) != -1
-        finally:
-            # mmap context manager is Python 3 only
-            mmf.close()
 
 
 def task_python_usage(logs, koji_build, artifact):

--- a/test/functional/test_common.py
+++ b/test/functional/test_common.py
@@ -1,6 +1,6 @@
 import pytest
 
-from taskotron_python_versions.python_usage import file_contains
+from taskotron_python_versions.common import file_contains
 
 from .common import gpkg_path
 

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -159,7 +159,7 @@ docutils = fixtures_factory('_docutils')
 _nodejs = fixtures_factory('nodejs-semver-5.1.1-2.fc26')
 nodejs = fixtures_factory('_nodejs')
 
-_bucky = fixtures_factory('python-bucky-2.2.2-7.fc27')
+_bucky = fixtures_factory('python-bucky-2.2.2-9.fc28')
 bucky = fixtures_factory('_bucky')
 
 _jsonrpc = fixtures_factory('jsonrpc-glib-3.27.4-1.fc28')
@@ -220,13 +220,14 @@ def test_artifact_contains_two_three_and_looks_as_expected(tracer):
     ''').strip().format(result.item) in artifact.strip()
 
 
-@pytest.mark.parametrize('results', ('eric', 'epub', 'twine', 'vdirsyncer'))
+@pytest.mark.parametrize('results', ('eric', 'epub', 'twine', 'vdirsyncer',
+                                     'bucky'))
 def test_naming_scheme_passed(results, request):
     results = request.getfixturevalue(results)
     assert results['dist.python-versions.naming_scheme'].outcome == 'PASSED'
 
 
-@pytest.mark.parametrize('results', ('copr', 'six', 'admesh', 'bucky'))
+@pytest.mark.parametrize('results', ('copr', 'six', 'admesh'))
 def test_naming_scheme_failed(results, request):
     results = request.getfixturevalue(results)
     assert results['dist.python-versions.naming_scheme'].outcome == 'FAILED'
@@ -367,6 +368,34 @@ def test_artifact_contains_unversioned_shebangs_and_looks_as_expected(
         This is discouraged and should be avoided. Please check the shebangs
         and use either `#!/usr/bin/python2` or `#!/usr/bin/python3`.
    """).strip() in artifact.strip()
+
+
+@pytest.mark.parametrize('results', ('bucky',))
+def test_unvesioned_shebangs_mangled_failed(results, request):
+    results = request.getfixturevalue(results)
+    result = results['dist.python-versions.unversioned_shebangs']
+    assert result.outcome == 'FAILED'
+
+
+def test_artifact_contains_mangled_unversioned_shebangs_and_looks_as_expected(
+        bucky):
+    result = bucky['dist.python-versions.unversioned_shebangs']
+    with open(result.artifact) as f:
+        artifact = f.read()
+
+    print(artifact)
+
+    assert dedent("""
+        The package uses either `#!/usr/bin/python` or
+        `#!/usr/bin/env python` shebangs. They are forbidden by the guidelines
+        and have been automatically mangled during build on the following
+        arches:
+
+            noarch
+
+        Please check the shebangs and use either `#!/usr/bin/python2` or
+        `#!/usr/bin/python3` explicitly.
+    """).strip() in artifact.strip()
 
 
 @pytest.mark.parametrize('results', ('eric', 'six', 'admesh', 'tracer',


### PR DESCRIPTION
Update unversioned_shebangs task to also check for automatic shebangs mangling in build logs (#42 )

Keep the ambiguous shebangs check in place, in case brp script is disabled, but also check the build logs for the warning generated when the shebangs are automatically mangled. Fail the shebang check in both
cases.