### PR TITLE
Whitelist python2-devel from two three check

### DIFF
--- a/taskotron_python_versions/two_three.py
+++ b/taskotron_python_versions/two_three.py
@@ -54,6 +54,7 @@ MESSAGE = 'These RPMs require both Python 2 and Python 3:\n{}'
 WHITELIST = (
     'eric',  # https://bugzilla.redhat.com/show_bug.cgi?id=1342492
     'pungi',  # https://bugzilla.redhat.com/show_bug.cgi?id=1342497
+    'python2-devel',  # deliberately depends on python3-rpm-generators
 )
 
 


### PR DESCRIPTION
It deliberately depends on python3-rpm-generators