### PR TITLE
Whitelist python-cartopy-common as it does not depend on Python 2

### DIFF
--- a/taskotron_python_versions/two_three.py
+++ b/taskotron_python_versions/two_three.py
@@ -42,6 +42,7 @@ NAME_NOTS = (
     b'python-btchip-common',
     b'python-matplotlib-data',
     b'python-matplotlib-data-fonts',
+    b'python-cartopy-common',
 )
 
 


### PR DESCRIPTION
Resolves #53