### PR TITLE
Use `python-bugzilla` rather than `bugzilla` in setup.py install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     url='https://github.com/fedora-python/taskotron-python-versions',
     license='Public Domain',
     packages=find_packages(),
-    install_requires=['libarchive-c', 'bugzilla'],
+    install_requires=['libarchive-c', 'python-bugzilla'],
     setup_requires=['setuptools', 'pytest-runner'],
     tests_require=['pytest', 'pyyaml'],
     classifiers=[


### PR DESCRIPTION
What's `bugzilla` on PyPI is, apparently, a weekend project from 2015.

See:
    https://pypi.python.org/pypi/bugzilla
    https://pypi.python.org/pypi/python-bugzilla