### PR TITLE
tests.yml: print output of DNF

### DIFF
--- a/tests.yml
+++ b/tests.yml
@@ -22,6 +22,17 @@
         - python-bugzilla
         - libtaskotron-core
         - libtaskotron-fedora
+      register: dnf_output
+
+    - name: Print msg of DNF task
+      debug:
+        var: dnf_output.results[0].msg
+      when: "'msg' in dnf_output.results[0]"
+
+    - name: Print results of DNF task
+      debug:
+        var: dnf_output.results[0].results | sort
+      when: "'results' in dnf_output.results[0]"
 
     - name: Make sure taskotron results dir exists
       # this is for placing results.yml file


### PR DESCRIPTION
This helps in debugging problems, because you know which package
versions were installed.