### PR TITLE
Whitelist postgresql-upgrade from two three check

### DIFF
--- a/taskotron_python_versions/two_three.py
+++ b/taskotron_python_versions/two_three.py
@@ -59,7 +59,7 @@ WHITELIST = (
     'eric',  # https://bugzilla.redhat.com/show_bug.cgi?id=1342492
     'pungi',  # https://bugzilla.redhat.com/show_bug.cgi?id=1342497
     'python2-devel',  # deliberately depends on python3-rpm-generators
-    'postgresql-upgrade',  # https://bugzilla.redhat.com/show_bug.cgi?id=1571215
+    'postgresql-upgrade',  # rhbz#1571215
 )
 
 

--- a/taskotron_python_versions/two_three.py
+++ b/taskotron_python_versions/two_three.py
@@ -59,6 +59,7 @@ WHITELIST = (
     'eric',  # https://bugzilla.redhat.com/show_bug.cgi?id=1342492
     'pungi',  # https://bugzilla.redhat.com/show_bug.cgi?id=1342497
     'python2-devel',  # deliberately depends on python3-rpm-generators
+    'postgresql-upgrade',  # https://bugzilla.redhat.com/show_bug.cgi?id=1571215
 )
 
 


### PR DESCRIPTION
The python2 requirement is for upgrade compatibility from older Fedora versions.