### PR TITLE
Fix python_usage task

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,9 +17,9 @@ Currently the following checks are available:
 
 -  Whether the package uses versioned shebangs in its executables;
 
--  Whether the package supports Python 3 upstream but not in the package.
+-  Whether the package supports Python 3 upstream but not in the package;
 
--  Whether ``/usr/bin/python`` was invoked during the build.
+-  Whether the package requires ``/usr/bin/python`` (or ``python-unversioned-command``).
 
 
 Running

--- a/python_versions_check.py
+++ b/python_versions_check.py
@@ -23,6 +23,7 @@ from taskotron_python_versions import (
     task_unversioned_shebangs,
     task_py3_support,
     task_python_usage,
+    task_python_usage_obsoleted,
 )
 from taskotron_python_versions.common import log, Package, PackageException
 
@@ -73,7 +74,10 @@ def run(koji_build, workdir='.', artifactsdir='artifacts',
         packages, logs, koji_build, artifact))
     details.append(task_py3_support(
         srpm_packages + packages, koji_build, artifact))
-    details.append(task_python_usage(logs, koji_build, artifact))
+    details.append(task_python_usage(
+        srpm_packages + packages, koji_build, artifact))
+    details.append(task_python_usage_obsoleted(
+        logs, koji_build, artifact))  # TODO: remove with Fedora 28 EOL.
 
     for detail in details:
         # update testcase for all subtasks (use their existing testcase as a

--- a/taskotron_python_versions/__init__.py
+++ b/taskotron_python_versions/__init__.py
@@ -5,6 +5,7 @@ from .two_three import task_two_three
 from .unversioned_shebangs import task_unversioned_shebangs
 from .py3_support import task_py3_support
 from .python_usage import task_python_usage
+from .python_usage_obsoleted import task_python_usage_obsoleted
 
 
 __all__ = (
@@ -15,4 +16,5 @@ __all__ = (
     'task_unversioned_shebangs',
     'task_py3_support',
     'task_python_usage',
+    'task_python_usage_obsoleted',
 )

--- a/taskotron_python_versions/python_usage_obsoleted.py
+++ b/taskotron_python_versions/python_usage_obsoleted.py
@@ -1,0 +1,65 @@
+"""Remove after Fedora 28 EOL.
+
+Obsoleted by https://fedoraproject.org/wiki/Changes/
+Move_usr_bin_python_into_separate_package.
+"""
+from .common import log, write_to_artifact, file_contains
+
+
+WARNING = 'DEPRECATION WARNING: python2 invoked with /usr/bin/python'
+
+MESSAGE = """You've used /usr/bin/python during build on the following arches:
+
+  {{}}
+
+Use /usr/bin/python3 or /usr/bin/python2 explicitly.
+/usr/bin/python will be removed or switched to Python 3 in the future.
+
+Grep the build.log for the following to find out where:
+
+    {}
+""".format(WARNING)
+
+INFO_URL = ('https://fedoraproject.org/wiki/Changes/'
+            'Avoid_usr_bin_python_in_RPM_Build')
+
+
+def task_python_usage_obsoleted(logs, koji_build, artifact):
+    """Parses the build.logs for /usr/bin/python invocation warning
+    """
+    # libtaskotron is not available on Python 3, so we do it inside
+    # to make the above functions testable anyway
+    from libtaskotron import check
+
+    outcome = 'PASSED'
+
+    problem_arches = set()
+
+    for buildlog in logs:  # not "log" because we use that name for logging
+        log.debug('Will parse {}'.format(buildlog))
+
+        if file_contains(buildlog, WARNING):
+            log.debug('{} contains our warning'.format(buildlog))
+            _, _, arch = buildlog.rpartition('.')
+            problem_arches.add(arch)
+            outcome = 'FAILED'
+
+    detail = check.CheckDetail(
+        checkname='python_usage_obsoleted',
+        item=koji_build,
+        report_type=check.ReportType.KOJI_BUILD,
+        outcome=outcome)
+
+    if problem_arches:
+        detail.artifact = artifact
+        info = '{}: {}'.format(koji_build, ', '.join(sorted(problem_arches)))
+        write_to_artifact(artifact, MESSAGE.format(info), INFO_URL)
+        problems = 'Problematic architectures: ' + info
+    else:
+        problems = 'No problems found.'
+
+    summary = 'subcheck python_usage {} for {}. {}'.format(
+        outcome, koji_build, problems)
+    log.info(summary)
+
+    return detail

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -176,8 +176,12 @@ nodejs = fixtures_factory('_nodejs')
 _pycallgraph = fixtures_factory('python-pycallgraph-0.5.1-13.fc28')
 pycallgraph = fixtures_factory('_pycallgraph')
 
+# TODO: remove with Fedora 28 EOL.
 _jsonrpc = fixtures_factory('jsonrpc-glib-3.27.4-1.fc28')
 jsonrpc = fixtures_factory('_jsonrpc')
+
+_teeworlds = fixtures_factory('teeworlds-0.6.4-8.fc29')
+teeworlds = fixtures_factory('_teeworlds')
 
 
 def parametrize(*fixtrues):
@@ -185,14 +189,14 @@ def parametrize(*fixtrues):
 
 
 @parametrize('eric', 'six', 'admesh', 'tracer', 'copr', 'epub', 'twine', 'yum',
-             'vdirsyncer', 'docutils', 'nodejs', 'pycallgraph', 'jsonrpc')
+             'vdirsyncer', 'docutils', 'nodejs', 'pycallgraph', 'teeworlds')
 def test_number_of_results(results, request):
     # getting a fixture by name
     # https://github.com/pytest-dev/pytest/issues/349#issuecomment-112203541
     results = request.getfixturevalue(results)
 
     # Each time a new check is added, this number needs to be increased
-    assert len(results) == 8
+    assert len(results) == 9
 
 
 @parametrize('eric', 'six', 'admesh', 'copr', 'epub', 'twine', 'pycallgraph')
@@ -475,26 +479,29 @@ def test_artifact_contains_py3_support_and_looks_as_expected(
     """).strip() in artifact.strip()
 
 
+# TODO: remove with Fedora 28 EOL.
 @parametrize('eric', 'six', 'admesh', 'tracer',
              'copr', 'epub', 'twine', 'docutils')
-def test_python_usage_passed(results, request):
+def test_python_usage_obsoleted_passed(results, request):
     results = request.getfixturevalue(results)
-    task_result = results['dist.python-versions.python_usage']
+    task_result = results['dist.python-versions.python_usage_obsoleted']
     assert task_result.outcome == 'PASSED'
 
 
+# TODO: remove with Fedora 28 EOL.
 @parametrize('jsonrpc')
-def test_python_usage_failed(results, request):
+def test_python_usage_obsoleted_failed(results, request):
     results = request.getfixturevalue(results)
-    task_result = results['dist.python-versions.python_usage']
+    task_result = results['dist.python-versions.python_usage_obsoleted']
     assert task_result.outcome == 'FAILED'
 
 
+# TODO: remove with Fedora 28 EOL.
 @parametrize('jsonrpc')
-def test_artifact_contains_python_usage_and_looks_as_expected(results,
+def test_artifact_of_python_usage_obsoleted_looks_as_expected(results,
                                                               request):
     results = request.getfixturevalue(results)
-    result = results['dist.python-versions.python_usage']
+    result = results['dist.python-versions.python_usage_obsoleted']
     with open(result.artifact) as f:
         artifact = f.read()
 
@@ -511,4 +518,40 @@ def test_artifact_contains_python_usage_and_looks_as_expected(results,
         Grep the build.log for the following to find out where:
 
             DEPRECATION WARNING: python2 invoked with /usr/bin/python
+    """).strip() in artifact.strip()
+
+
+@parametrize('eric', 'six', 'admesh',
+             'copr', 'epub', 'twine', 'docutils')
+def test_python_usage_passed(results, request):
+    results = request.getfixturevalue(results)
+    task_result = results['dist.python-versions.python_usage']
+    assert task_result.outcome == 'PASSED'
+
+
+@parametrize('tracer', 'yum', 'teeworlds')
+def test_python_usage_failed(results, request):
+    results = request.getfixturevalue(results)
+    task_result = results['dist.python-versions.python_usage']
+    assert task_result.outcome == 'FAILED'
+
+
+@parametrize('teeworlds')
+def test_artifact_contains_python_usage_and_looks_as_expected(results,
+                                                              request):
+    results = request.getfixturevalue(results)
+    result = results['dist.python-versions.python_usage']
+    with open(result.artifact) as f:
+        artifact = f.read()
+
+    print(artifact)
+
+    assert dedent("""
+        The following packages (Build)Require `/usr/bin/python`
+        (or `python-unversioned-command`):
+
+          * teeworlds-0.6.4-8.fc29.src.rpm
+
+        Use /usr/bin/python3 or /usr/bin/python2 explicitly.
+        /usr/bin/python will be removed or switched to Python 3 in the future.
     """).strip() in artifact.strip()

--- a/test/integration/test_integration.py
+++ b/test/integration/test_integration.py
@@ -177,7 +177,7 @@ _pycallgraph = fixtures_factory('python-pycallgraph-0.5.1-13.fc28')
 pycallgraph = fixtures_factory('_pycallgraph')
 
 # TODO: remove with Fedora 28 EOL.
-_jsonrpc = fixtures_factory('jsonrpc-glib-3.27.4-1.fc28')
+_jsonrpc = fixtures_factory('jsonrpc-glib-3.27.4-2.fc28')
 jsonrpc = fixtures_factory('_jsonrpc')
 
 _teeworlds = fixtures_factory('teeworlds-0.6.4-8.fc29')
@@ -510,7 +510,7 @@ def test_artifact_of_python_usage_obsoleted_looks_as_expected(results,
     assert dedent("""
         You've used /usr/bin/python during build on the following arches:
 
-          jsonrpc-glib-3.27.4-1.fc28: x86_64
+          jsonrpc-glib-3.27.4-2.fc28: x86_64
 
         Use /usr/bin/python3 or /usr/bin/python2 explicitly.
         /usr/bin/python will be removed or switched to Python 3 in the future.


### PR DESCRIPTION
Instead of parsing logs for `/usr/bin/python` usage, check if the source package requires
`/usr/bin/python` or `python-unversioned-command`
(https://fedoraproject.org/wiki/Changes/Move_usr_bin_python_into_separate_package).

Fix for #65. 