### PR TITLE
playbook: retry dnf for network failures

### DIFF
--- a/tests.yml
+++ b/tests.yml
@@ -23,6 +23,10 @@
         - libtaskotron-core
         - libtaskotron-fedora
       register: dnf_output
+      # retry for network failures
+      retries: 3
+      delay: 30
+      until: dnf_output is succeeded
 
     - name: Print msg of DNF task
       debug:


### PR DESCRIPTION
This makes the task more reliable if there are temporary network issues
with dnf repos.