### PR TITLE
tests.yml: remove unneeded taskotron dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ services:
   - docker
 
 env:
-  - FEDORA=27
   - FEDORA=28
   - FEDORA=29
   - FEDORA=rawhide

--- a/tests.yml
+++ b/tests.yml
@@ -13,15 +13,13 @@
   tasks:
     - name: Install required packages
       dnf:
-        name: "{{ item }}"
+        name:
+          - python3-rpm
+          - python3-dnf
+          - python3-libarchive-c
+          - python3-bugzilla
+          - python3-libtaskotron
         state: latest
-      with_items:
-        - python3-rpm
-        - python3-dnf
-        - python3-libarchive-c
-        - python3-bugzilla
-        - python3-libtaskotron
-        - taskotron-runner
       register: dnf_output
       # retry for network failures
       retries: 3


### PR DESCRIPTION
Only the library is required to run, the whole runner pulls in a large
set of dependencies.

Also remove an ansible deprecation warning (using dnf with with_items).