### PR TITLE
python-basemap-data is not a Python 2 package

### DIFF
--- a/taskotron_python_versions/two_three.py
+++ b/taskotron_python_versions/two_three.py
@@ -54,6 +54,7 @@ NAME_NOTS = (
     'python-jupyter-filesystem',
     'python-imgcreate-sysdeps',
     'dbus-python-devel',
+    'python-basemap-data',
 )
 
 


### PR DESCRIPTION
Fixes https://github.com/fedora-python/taskotron-python-versions/issues/83