### PR TITLE
Add couple more not Python 2 packages

### DIFF
--- a/taskotron_python_versions/two_three.py
+++ b/taskotron_python_versions/two_three.py
@@ -58,6 +58,11 @@ NAME_NOTS = (
     'python-basemap-data',
     'python-guessit-doc',
     'python-jupyter-client-doc',
+    'python-pymilter-common',
+    'python-pymilter-selinux',
+    'gcc-python-plugin-c-api',
+    'gcc-python-plugin-docs',
+    'python-pyside-devel',
 )
 
 


### PR DESCRIPTION
- python-pyside-devel requires both Python 2 and Python 3
- the rest is version agnostic